### PR TITLE
Use task.spawn (or task.defer) and localize table.insert

### DIFF
--- a/Source.lua
+++ b/Source.lua
@@ -1,7 +1,10 @@
+local IS_DEFERRED = false
+
+local t_insert = table.insert
 local o_clock = os.clock
 local c_yield = coroutine.yield
 local c_running = coroutine.running
-local c_resume = coroutine.resume
+local runThread = IS_DEFFERED and task.defer or task.spawn
 
 local Yields = {}
 game:GetService('RunService').Stepped:Connect(function()
@@ -10,13 +13,13 @@ game:GetService('RunService').Stepped:Connect(function()
 		local Spent = Clock - data[1]
 		if Spent >= data[2] then
 			Yields[Idx] = nil
-			c_resume(data[3], Spent, Clock)
+			runThread(data[3], Spent, Clock)
 		end
 	end
 end)
 
 return function(Time)
 	Time = (type(Time) ~= 'number' or Time < 0) and 0 or Time
-	table.insert(Yields, {o_clock(), Time, c_running()})
+	t_insert(Yields, {o_clock(), Time, c_running()})
 	return c_yield()
 end


### PR DESCRIPTION
Last time I forgot to make `table.insert` a local, so I did that

Also make it into use `task.spawn` (or `task.defer`), `coroutine.resume` made it so that errors were silent, the task functions don't do that, I would guess you would want that;

You can change it to use `task.defer` instead, there's a variable called `IS_DEFERRED` which defines that behaviour. I believe I left it as disabled, to use spawn instead, I could be wrong, I prefer using `task.defer` as it's way faster to go through every yield and resume it.